### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/send-webmentions.yml
+++ b/.github/workflows/send-webmentions.yml
@@ -1,5 +1,8 @@
 name: Send Webmentions
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/funkylarma/adamchamberlin.info/security/code-scanning/1](https://github.com/funkylarma/adamchamberlin.info/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow does not interact with the repository's contents or other GitHub features, we will set `contents: read` as the only permission. This ensures the workflow adheres to the principle of least privilege.

The changes will be made at the root level of the workflow file, `.github/workflows/send-webmentions.yml`, to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
